### PR TITLE
Protobuf Refactor

### DIFF
--- a/fake-runtime/FakeRuntime.js
+++ b/fake-runtime/FakeRuntime.js
@@ -10,9 +10,13 @@ const dgram = require('dgram');
 const net = require('net');
 const protobuf = require('protobufjs');
 
-const DawnData = (new protobuf.Root()).loadSync('../ansible-protos/ansible.proto', { keepCase: true }).lookupType('DawnData');
-const RuntimeData = (new protobuf.Root()).loadSync('../ansible-protos/runtime.proto', { keepCase: true }).lookupType('RuntimeData');
-const Notification = (new protobuf.Root()).loadSync('../ansible-protos/notification.proto', { keepCase: true }).lookupType('Notification');
+/**
+ * TODO: Fake Runtime is currently broken because it still relies on the old protobufs and
+ * Ansible now uses the new protobufs. Fix by porting Fake Runtime over to new protos.
+ */
+const DawnData = (new protobuf.Root()).loadSync('old-protos/ansible.proto', { keepCase: true }).lookupType('DawnData');
+const RuntimeData = (new protobuf.Root()).loadSync('old-protos/runtime.proto', { keepCase: true }).lookupType('RuntimeData');
+const Notification = (new protobuf.Root()).loadSync('old-protos/notification.proto', { keepCase: true }).lookupType('Notification');
 
 const TCPPORT = 1234;
 const SENDPORT = 1235;

--- a/main/networking/Ansible.js
+++ b/main/networking/Ansible.js
@@ -14,7 +14,7 @@ import { Logger, defaults } from '../../renderer/utils/utils';
  * UDP Recv (Runtime -> Dawn)
  * Device Data Array (sensors), device.proto
  */
-const RecvDeviceProto = (new protobuf.Root()).loadSync('protos/device.proto', { keepCase: true }).lookupType('Device');
+const RecvDeviceProto = (new protobuf.Root()).loadSync('protos/device.proto', { keepCase: true }).lookupType('DevData');
 
 /**
  * UDP Send (Dawn -> Runtime)
@@ -73,6 +73,7 @@ class ListenSocket {
      */
     this.socket.on('message', (msg) => {
       try {
+        console.log(msg);
         const sensorData = RecvDeviceProto.decode(msg).devices;
         this.logger.debug(`Dawn received UDP with data ${JSON.stringify(sensorData)}`);
         RendererBridge.reduxDispatch(updatePeripherals(sensorData));

--- a/old-protos/ansible.proto
+++ b/old-protos/ansible.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+message DawnData {
+    enum StudentCodeStatus {
+        IDLE = 0;
+        TELEOP = 1;
+        AUTONOMOUS = 2;
+        ESTOP = 3;
+    }
+
+    enum TeamColor {
+        NONE = 0;
+        BLUE = 1;
+        GOLD = 2;
+    }
+
+    message Gamepad {
+        int32 index = 1; // Gamepad index, there may be up to 4
+        repeated double axes = 2;
+        repeated bool buttons = 3;
+    }
+
+    message Gamecode {
+        int32 code = 1;
+    }
+
+    StudentCodeStatus student_code_status = 1;
+    repeated Gamepad gamepads = 2;
+    repeated string peripheral_names = 3;
+    TeamColor team_color = 4;
+    Gamecode gamecode = 5;
+}

--- a/old-protos/notification.proto
+++ b/old-protos/notification.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+message Notification {
+    enum Type {
+        CONSOLE_LOGGING = 0;
+        STUDENT_SENT = 1;
+        STUDENT_RECEIVED = 2;
+        STUDENT_NOT_RECEIVED = 3;
+        SENSOR_MAPPING = 4;
+        TIMESTAMP_UP = 5;
+        TIMESTAMP_DOWN = 6;
+        GAMECODE_TRANSMISSION = 7;
+    }
+    message SensorMapping {
+        string device_uid = 1;
+        string device_student_name = 2;
+    }
+    Type header = 1;
+    string console_output = 2;   // Console Output From Runtime to Dawn
+    repeated SensorMapping sensor_mapping = 3;
+    repeated double timestamps = 4;
+    repeated int32 gamecode_solutions = 5;
+    repeated int32 gamecodes = 6;
+    repeated int32 rfids = 7;
+}

--- a/old-protos/runtime.proto
+++ b/old-protos/runtime.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+message RuntimeData {
+    enum State {
+        STUDENT_CRASHED = 0;
+        STUDENT_RUNNING = 1;
+        STUDENT_STOPPED = 2;
+        TELEOP = 3;
+        AUTO = 4;
+        ESTOP = 5;
+    }
+    message ParamValue {
+        string param = 1;
+        oneof kind {
+            float float_value = 2;
+            int32 int_value = 3;
+            bool bool_value = 4;
+        }
+    }
+    message SensorData {
+        reserved "value";
+        reserved 3;
+        string device_type = 1;
+        string device_name = 2;
+        string uid = 4;
+        uint32 int_device_type = 5;
+        repeated ParamValue param_value = 6;
+    }
+    State robot_state = 1;
+    repeated SensorData sensor_data = 2;
+}

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   },
   "betterScripts": {
     "start": {
-      "command": "cp ../ansible-protos/*.proto ./build && electron build/main.js",
+      "command": "electron build/main.js",
       "env": {
         "NODE_ENV": "development"
       }
     },
     "build": {
-      "command": "mkdir -p ./build && cp ../ansible-protos/*.proto ./build && webpack --mode production --progress",
+      "command": "mkdir -p ./build && webpack --mode production --progress",
       "env": {
         "NODE_ENV": "production"
       }

--- a/protos/device.proto
+++ b/protos/device.proto
@@ -1,0 +1,29 @@
+/*
+ * Defines a message for communicating Device Data
+ */
+
+syntax = "proto3";
+
+option optimize_for = LITE_RUNTIME;
+
+//message for describing a single device parameter
+message Param {
+	string name = 1;
+	oneof val {
+		float fval = 2;
+		int32 ival = 3;
+		bool bval = 4;
+	}
+}
+
+//message for describing a single device
+message Device {
+	string name = 1;
+	uint64 uid = 2;
+	int32 type = 3;
+	repeated Param params = 4; //each device has some number of params
+}
+
+message DevData {
+	repeated Device devices = 1; //this single field has information about all requested params of devices
+}

--- a/protos/gamepad.proto
+++ b/protos/gamepad.proto
@@ -1,0 +1,13 @@
+/*
+ * Defines a message for communicating GamePad state
+ */
+
+syntax = "proto3";
+
+option optimize_for = LITE_RUNTIME;
+
+message GpState {
+	bool connected = 1;
+	fixed32 buttons = 2;
+	repeated float axes = 3;
+}

--- a/protos/run_mode.proto
+++ b/protos/run_mode.proto
@@ -1,0 +1,19 @@
+/*
+ * Defines a message for communicating the run mode
+ */
+
+syntax = "proto3";
+
+option optimize_for = LITE_RUNTIME;
+
+enum Mode {
+	IDLE = 0;
+	AUTO = 1;
+	TELEOP = 2;
+	ESTOP = 3;
+	CHALLENGE = 4;
+}
+
+message RunMode {
+	Mode mode = 1;
+}

--- a/protos/start_pos.proto
+++ b/protos/start_pos.proto
@@ -1,0 +1,14 @@
+//Message for communicating starting position
+
+syntax = "proto3";
+
+option optimize_for = LITE_RUNTIME;
+
+enum Pos {       //we can add more start positions in the future
+	LEFT = 0;
+	RIGHT = 1;
+}
+
+message StartPos {
+	Pos pos = 1;
+}

--- a/protos/text.proto
+++ b/protos/text.proto
@@ -1,0 +1,12 @@
+/*
+ * Defines a message for communicating text data
+ */
+
+syntax = "proto3";
+
+option optimize_for = LITE_RUNTIME;
+
+message Text {
+	repeated string payload = 1;   //CHALLENGE_DATA: initial values or results of challenges
+								   //LOG: list of log lines
+}

--- a/renderer/utils/sagas.js
+++ b/renderer/utils/sagas.js
@@ -561,7 +561,6 @@ function* exportRunMode() {
   ipcRenderer.send('EXPORT_RUN_MODE', stateSlice);
 }
 
-
 /**
  * The root saga combines all the other sagas together into one.
  */

--- a/renderer/utils/sagas.js
+++ b/renderer/utils/sagas.js
@@ -305,7 +305,6 @@ function* ansibleSaga() {
 }
 
 const gamepadsState = state => ({
-  studentCodeStatus: state.info.studentCodeStatus,
   gamepads: state.gamepads.gamepads,
 });
 
@@ -555,6 +554,13 @@ function timestampBounceback() {
   ipcRenderer.send('TIMESTAMP_SEND');
 }
 
+function* exportRunMode() {
+  const stateSlice = yield select(state => ({
+    studentCodeStatus: state.info.studentCodeStatus
+  }));
+  ipcRenderer.send('EXPORT_RUN_MODE', stateSlice);
+}
+
 
 /**
  * The root saga combines all the other sagas together into one.
@@ -571,6 +577,7 @@ export default function* rootSaga() {
     takeEvery('UPLOAD_CODE', uploadStudentCode),
     takeEvery('TOGGLE_FIELD_CONTROL', handleFieldControl),
     takeEvery('TIMESTAMP_CHECK', timestampBounceback),
+    takeEvery('EXPORT_RUN_MODE', exportRunMode),
     fork(runtimeHeartbeat),
     fork(ansibleGamepads),
     fork(ansibleSaga),


### PR DESCRIPTION
- Incorporated new protobufs for new UDP/TCP send and receive
- UDP Dawn to Runtime: switched to `gamepad.proto`, but needs to be tested
- UDP Runtime to Dawn: switched to `device.proto`, but needs to be tested
- TCP Dawn to Runtime: implemented `run_mode.proto` (needs testing), but `device_data`, `challenge_data`, and `start_pos` all need to be worked on (perhaps on separate issues)
- TCP Runtime to Dawn: switched to use `text.proto`, but need clarification on distinguishing logs and challenge output
- Fake Runtime needs to be fixed to adhere to new protobufs
