### PR TITLE
Fix keyboard connected

### DIFF
--- a/main/networking/Runtime.ts
+++ b/main/networking/Runtime.ts
@@ -450,7 +450,6 @@ class UDPConn {
    * or when 100 ms has passed (with 50 ms cooldown)
    */
   sendInputs = (_event: IpcMainEvent, data: protos.Input[], source: protos.Source) => {
-    
     if (data.length === 0) {
       data.push(
         protos.Input.create({

--- a/main/networking/Runtime.ts
+++ b/main/networking/Runtime.ts
@@ -450,6 +450,7 @@ class UDPConn {
    * or when 100 ms has passed (with 50 ms cooldown)
    */
   sendInputs = (_event: IpcMainEvent, data: protos.Input[], source: protos.Source) => {
+    
     if (data.length === 0) {
       data.push(
         protos.Input.create({

--- a/renderer/components/Editor.tsx
+++ b/renderer/components/Editor.tsx
@@ -70,6 +70,7 @@ interface OwnProps {
   onDownloadCode: () => void;
   onUploadCode: () => void;
   onUpdateKeyboardBitmap: (keyboardBitmap: number) => void;
+  onUpdateKeyboardModeToggle: (isKeyboardToggled: boolean) => void;
 }
 
 type Props = StateProps & OwnProps;
@@ -277,17 +278,19 @@ export class Editor extends React.Component<Props, State> {
 
   // toggle keyboard control and add/remove listening for key presses to control robot
   toggleKeyboardControl = () => {
-    this.setState({ isKeyboardModeToggled: !this.state.isKeyboardModeToggled });
+    const { isKeyboardModeToggled } = this.state;
+    this.setState({ isKeyboardModeToggled: !isKeyboardModeToggled });
+    this.props.onUpdateKeyboardModeToggle(!isKeyboardModeToggled);
 
-    if (!this.state.isKeyboardModeToggled) {
+    if (!isKeyboardModeToggled) {
       // We need passive true so that we are able to remove the event listener when we are not in Keyboard Control mode
       window.addEventListener('keydown', this.turnCharacterOn, { passive: true });
       window.addEventListener('keyup', this.turnCharacterOff, { passive: true });
     } else {
       window.removeEventListener('keydown', this.turnCharacterOn);
       window.removeEventListener('keyup', this.turnCharacterOff);
-      this.setState({ keyboardBitmap: 0 });
-      this.props.onUpdateKeyboardBitmap(this.state.keyboardBitmap);
+      // this.setState({ keyboardBitmap: 0 });
+      // this.props.onUpdateKeyboardBitmap(this.state.keyboardBitmap);
     }
   };
 

--- a/renderer/components/Editor.tsx
+++ b/renderer/components/Editor.tsx
@@ -289,8 +289,6 @@ export class Editor extends React.Component<Props, State> {
     } else {
       window.removeEventListener('keydown', this.turnCharacterOn);
       window.removeEventListener('keyup', this.turnCharacterOff);
-      // this.setState({ keyboardBitmap: 0 });
-      // this.props.onUpdateKeyboardBitmap(this.state.keyboardBitmap);
     }
   };
 

--- a/renderer/components/EditorContainer.ts
+++ b/renderer/components/EditorContainer.ts
@@ -8,7 +8,8 @@ import {
   createNewFile,
   downloadCode,
   uploadCode,
-  updateKeyboardBitmap
+  updateKeyboardBitmap,
+  updateIsKeyboardModeToggled
 } from '../actions/EditorActions';
 import { changeTheme, changeFontSize } from '../actions/SettingsActions';
 import { toggleConsole, clearConsole } from '../actions/ConsoleActions';
@@ -78,6 +79,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
   onUpdateKeyboardBitmap: (keyboardBitmap: number) => {
     dispatch(updateKeyboardBitmap(keyboardBitmap));
+  },
+  onUpdateKeyboardModeToggle: (isKeyboardToggled: boolean) => {
+    dispatch(updateIsKeyboardModeToggled(isKeyboardToggled));
   }
 });
 

--- a/renderer/utils/sagas.ts
+++ b/renderer/utils/sagas.ts
@@ -258,6 +258,21 @@ function formatGamepads(newGamepads: (Gamepad | null)[]): Input[] {
   return formattedGamepads;
 }
 
+/*
+ Send a packet to runtime telling them when keyboard is connected/disconnected
+*/
+function* sendKeyboardConnectionStatus() {
+  const currEditorState = yield select(editorState);
+
+  const keyboardConnected = new Input({
+    connected: currEditorState.isKeyboardModeToggled,
+    axes: [],
+    buttons: 0,
+    source: Source.KEYBOARD
+  })
+  ipcRenderer.send('stateUpdate', [keyboardConnected], Source.KEYBOARD);
+}
+
 function* sendKeyboardInputs() {
   const currEditorState = yield select(editorState);
 
@@ -615,6 +630,7 @@ export default function* rootSaga() {
     takeEvery('TOGGLE_FIELD_CONTROL', handleFieldControl),
     takeEvery('TIMESTAMP_CHECK', timestampBounceback),
     takeEvery('UPDATE_KEYBOARD_BITMAP', sendKeyboardInputs),
+    takeEvery('UPDATE_IS_KEYBOARD_MODE_TOGGLED', sendKeyboardConnectionStatus),
     fork(runtimeHeartbeat),
     fork(runtimeGamepads),
     fork(runtimeSaga),

--- a/renderer/utils/sagas.ts
+++ b/renderer/utils/sagas.ts
@@ -267,15 +267,16 @@ function* sendKeyboardConnectionStatus() {
   const keyboardConnected = new Input({
     connected: currEditorState.isKeyboardModeToggled,
     axes: [],
-    buttons: 0,
+    buttons: 1,
     source: Source.KEYBOARD
   })
+  
   ipcRenderer.send('stateUpdate', [keyboardConnected], Source.KEYBOARD);
 }
 
 function* sendKeyboardInputs() {
   const currEditorState = yield select(editorState);
-
+  
   const keyboard = new Input({
     connected: true,
     axes: [],

--- a/renderer/utils/sagas.ts
+++ b/renderer/utils/sagas.ts
@@ -259,24 +259,24 @@ function formatGamepads(newGamepads: (Gamepad | null)[]): Input[] {
 }
 
 /*
- Send a packet to runtime telling them when keyboard is connected/disconnected
+ Send an update to Runtime indicating whether keyboard mode is on/off
 */
 function* sendKeyboardConnectionStatus() {
   const currEditorState = yield select(editorState);
 
-  const keyboardConnected = new Input({
+  const keyboardConnectionStatus = new Input({
     connected: currEditorState.isKeyboardModeToggled,
     axes: [],
     buttons: 0,
     source: Source.KEYBOARD
   });
 
-  ipcRenderer.send('stateUpdate', [keyboardConnected], Source.KEYBOARD);
+  ipcRenderer.send('stateUpdate', [keyboardConnectionStatus], Source.KEYBOARD);
 }
 
 function* sendKeyboardInputs() {
   const currEditorState = yield select(editorState);
-  
+
   const keyboard = new Input({
     connected: true,
     axes: [],

--- a/renderer/utils/sagas.ts
+++ b/renderer/utils/sagas.ts
@@ -267,10 +267,10 @@ function* sendKeyboardConnectionStatus() {
   const keyboardConnected = new Input({
     connected: currEditorState.isKeyboardModeToggled,
     axes: [],
-    buttons: 1,
+    buttons: 0,
     source: Source.KEYBOARD
-  })
-  
+  });
+
   ipcRenderer.send('stateUpdate', [keyboardConnected], Source.KEYBOARD);
 }
 


### PR DESCRIPTION
Dawn now sends a packet saying that the keyboard is connected when the keyboard is toggled to robot control mode. When the keyboard is toggled off robot control mode, Dawn sends a packet saying the keyboard is disconnected. 