### PR TITLE
Fixed the negative latency issue

### DIFF
--- a/main/networking/Runtime.ts
+++ b/main/networking/Runtime.ts
@@ -296,7 +296,7 @@ class TCPConn {
             break;
           case MsgType.TIME_STAMPS:
             decoded = protos.TimeStamps.decode(packet.payload);
-            const latency = Number(decoded.runtimeTimestamp) - Number(decoded.dawnTimestamp);
+            const latency = Date.now() - Number(decoded.dawnTimestamp);
 
             // TODO: we can probably do an average of n timestamps so the display doesn't change too frequently
             


### PR DESCRIPTION
Instead of subtracting from runtime timestamp, subtract from the current dawn clock. 