### PR TITLE
Use `--force-message` for proto autogenerated files

### DIFF
--- a/main/networking/Runtime.ts
+++ b/main/networking/Runtime.ts
@@ -109,16 +109,16 @@ function createPacket(payload: unknown, messageType: MsgType): Buffer {
 
   switch (messageType) {
     case MsgType.DEVICE_DATA:
-      encodedPayload = protos.DevData.encode(payload as protos.IDevData).finish();
+      encodedPayload = protos.DevData.encode(protos.DevData.create(payload as protos.IDevData)).finish();
       break;
     case MsgType.RUN_MODE:
-      encodedPayload = protos.RunMode.encode(payload as protos.IRunMode).finish();
+      encodedPayload = protos.RunMode.encode(protos.RunMode.create(payload as protos.IRunMode)).finish();
       break;
     case MsgType.START_POS:
-      encodedPayload = protos.StartPos.encode(payload as protos.IStartPos).finish();
+      encodedPayload = protos.StartPos.encode(protos.StartPos.create(payload as protos.IStartPos)).finish();
       break;
     case MsgType.TIME_STAMPS:
-      encodedPayload = protos.TimeStamps.encode(payload as protos.ITimeStamps).finish();
+      encodedPayload = protos.TimeStamps.encode(protos.TimeStamps.create(payload as protos.ITimeStamps)).finish();
       break;
     case MsgType.INPUTS:
       encodedPayload = protos.UserInputs.encode(

--- a/main/networking/Runtime.ts
+++ b/main/networking/Runtime.ts
@@ -121,7 +121,9 @@ function createPacket(payload: unknown, messageType: MsgType): Buffer {
       encodedPayload = protos.TimeStamps.encode(payload as protos.ITimeStamps).finish();
       break;
     case MsgType.INPUTS:
-      encodedPayload = protos.UserInputs.encode({ inputs: payload as protos.Input[] }).finish();
+      encodedPayload = protos.UserInputs.encode(
+        protos.UserInputs.create({ inputs: payload as protos.Input[] } as protos.IUserInputs)
+      ).finish();
       break;
     default:
       console.log('ERROR: trying to create TCP Packet with unknown message type');

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint '*/**/*.ts?(x)'",
     "lintfix": "eslint '*/**/*.ts?(x)' --fix",
     "postinstall": "patch-package",
-    "build-protos": "pbjs -t static-module -w es6 -o protos-main/protos.js protos-main/protos/*.proto && pbts -o protos-main/protos.d.ts protos-main/protos.js ",
+    "build-protos": "pbjs -t static-module --force-message -w es6 -o protos-main/protos.js protos-main/protos/*.proto && pbts -o protos-main/protos.d.ts protos-main/protos.js ",
     "watch": "webpack --mode development --watch --progress",
     "test": "mocha --require babel-core/register --recursive renderer/**/test/*.test.js",
     "release": "yarn build && ts-node release.ts",

--- a/protos-main/protos.d.ts
+++ b/protos-main/protos.d.ts
@@ -58,7 +58,7 @@ export class Param implements IParam {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IParam, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: Param, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified Param message, length delimited. Does not implicitly {@link Param.verify|verify} messages.
@@ -66,7 +66,7 @@ export class Param implements IParam {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IParam, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: Param, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a Param message from the specified reader or buffer.
@@ -129,7 +129,7 @@ export interface IDevice {
     type?: (number|null);
 
     /** Device params */
-    params?: (IParam[]|null);
+    params?: (Param[]|null);
 }
 
 /** Represents a Device. */
@@ -166,7 +166,7 @@ export class Device implements IDevice {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IDevice, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: Device, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified Device message, length delimited. Does not implicitly {@link Device.verify|verify} messages.
@@ -174,7 +174,7 @@ export class Device implements IDevice {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IDevice, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: Device, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a Device message from the specified reader or buffer.
@@ -228,7 +228,7 @@ export class Device implements IDevice {
 export interface IDevData {
 
     /** DevData devices */
-    devices?: (IDevice[]|null);
+    devices?: (Device[]|null);
 }
 
 /** Represents a DevData. */
@@ -256,7 +256,7 @@ export class DevData implements IDevData {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IDevData, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: DevData, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified DevData message, length delimited. Does not implicitly {@link DevData.verify|verify} messages.
@@ -264,7 +264,7 @@ export class DevData implements IDevData {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IDevData, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: DevData, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a DevData message from the specified reader or buffer.
@@ -354,7 +354,7 @@ export class GameState implements IGameState {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IGameState, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: GameState, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified GameState message, length delimited. Does not implicitly {@link GameState.verify|verify} messages.
@@ -362,7 +362,7 @@ export class GameState implements IGameState {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IGameState, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: GameState, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a GameState message from the specified reader or buffer.
@@ -468,7 +468,7 @@ export class Input implements IInput {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IInput, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: Input, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified Input message, length delimited. Does not implicitly {@link Input.verify|verify} messages.
@@ -476,7 +476,7 @@ export class Input implements IInput {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IInput, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: Input, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes an Input message from the specified reader or buffer.
@@ -530,7 +530,7 @@ export class Input implements IInput {
 export interface IUserInputs {
 
     /** UserInputs inputs */
-    inputs?: (IInput[]|null);
+    inputs?: (Input[]|null);
 }
 
 /** Represents a UserInputs. */
@@ -558,7 +558,7 @@ export class UserInputs implements IUserInputs {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IUserInputs, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: UserInputs, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified UserInputs message, length delimited. Does not implicitly {@link UserInputs.verify|verify} messages.
@@ -566,7 +566,7 @@ export class UserInputs implements IUserInputs {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IUserInputs, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: UserInputs, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a UserInputs message from the specified reader or buffer.
@@ -656,7 +656,7 @@ export class RunMode implements IRunMode {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IRunMode, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: RunMode, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified RunMode message, length delimited. Does not implicitly {@link RunMode.verify|verify} messages.
@@ -664,7 +664,7 @@ export class RunMode implements IRunMode {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IRunMode, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: RunMode, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a RunMode message from the specified reader or buffer.
@@ -770,7 +770,7 @@ export class RuntimeStatus implements IRuntimeStatus {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IRuntimeStatus, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: RuntimeStatus, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified RuntimeStatus message, length delimited. Does not implicitly {@link RuntimeStatus.verify|verify} messages.
@@ -778,7 +778,7 @@ export class RuntimeStatus implements IRuntimeStatus {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IRuntimeStatus, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: RuntimeStatus, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a RuntimeStatus message from the specified reader or buffer.
@@ -866,7 +866,7 @@ export class StartPos implements IStartPos {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IStartPos, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: StartPos, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified StartPos message, length delimited. Does not implicitly {@link StartPos.verify|verify} messages.
@@ -874,7 +874,7 @@ export class StartPos implements IStartPos {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IStartPos, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: StartPos, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a StartPos message from the specified reader or buffer.
@@ -956,7 +956,7 @@ export class Text implements IText {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: IText, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: Text, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified Text message, length delimited. Does not implicitly {@link Text.verify|verify} messages.
@@ -964,7 +964,7 @@ export class Text implements IText {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: IText, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: Text, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a Text message from the specified reader or buffer.
@@ -1052,7 +1052,7 @@ export class TimeStamps implements ITimeStamps {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(message: ITimeStamps, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(message: TimeStamps, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Encodes the specified TimeStamps message, length delimited. Does not implicitly {@link TimeStamps.verify|verify} messages.
@@ -1060,7 +1060,7 @@ export class TimeStamps implements ITimeStamps {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(message: ITimeStamps, writer?: $protobuf.Writer): $protobuf.Writer;
+    public static encodeDelimited(message: TimeStamps, writer?: $protobuf.Writer): $protobuf.Writer;
 
     /**
      * Decodes a TimeStamps message from the specified reader or buffer.

--- a/protos-main/protos.js
+++ b/protos-main/protos.js
@@ -106,7 +106,7 @@ export const Param = $root.Param = (() => {
      * @function encode
      * @memberof Param
      * @static
-     * @param {IParam} message Param message or plain object to encode
+     * @param {Param} message Param message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -131,7 +131,7 @@ export const Param = $root.Param = (() => {
      * @function encodeDelimited
      * @memberof Param
      * @static
-     * @param {IParam} message Param message or plain object to encode
+     * @param {Param} message Param message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -323,7 +323,7 @@ export const Device = $root.Device = (() => {
      * @property {string|null} [name] Device name
      * @property {number|Long|null} [uid] Device uid
      * @property {number|null} [type] Device type
-     * @property {Array.<IParam>|null} [params] Device params
+     * @property {Array.<Param>|null} [params] Device params
      */
 
     /**
@@ -368,7 +368,7 @@ export const Device = $root.Device = (() => {
 
     /**
      * Device params.
-     * @member {Array.<IParam>} params
+     * @member {Array.<Param>} params
      * @memberof Device
      * @instance
      */
@@ -391,7 +391,7 @@ export const Device = $root.Device = (() => {
      * @function encode
      * @memberof Device
      * @static
-     * @param {IDevice} message Device message or plain object to encode
+     * @param {Device} message Device message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -415,7 +415,7 @@ export const Device = $root.Device = (() => {
      * @function encodeDelimited
      * @memberof Device
      * @static
-     * @param {IDevice} message Device message or plain object to encode
+     * @param {Device} message Device message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -610,7 +610,7 @@ export const DevData = $root.DevData = (() => {
      * Properties of a DevData.
      * @exports IDevData
      * @interface IDevData
-     * @property {Array.<IDevice>|null} [devices] DevData devices
+     * @property {Array.<Device>|null} [devices] DevData devices
      */
 
     /**
@@ -631,7 +631,7 @@ export const DevData = $root.DevData = (() => {
 
     /**
      * DevData devices.
-     * @member {Array.<IDevice>} devices
+     * @member {Array.<Device>} devices
      * @memberof DevData
      * @instance
      */
@@ -654,7 +654,7 @@ export const DevData = $root.DevData = (() => {
      * @function encode
      * @memberof DevData
      * @static
-     * @param {IDevData} message DevData message or plain object to encode
+     * @param {DevData} message DevData message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -672,7 +672,7 @@ export const DevData = $root.DevData = (() => {
      * @function encodeDelimited
      * @memberof DevData
      * @static
-     * @param {IDevData} message DevData message or plain object to encode
+     * @param {DevData} message DevData message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -879,7 +879,7 @@ export const GameState = $root.GameState = (() => {
      * @function encode
      * @memberof GameState
      * @static
-     * @param {IGameState} message GameState message or plain object to encode
+     * @param {GameState} message GameState message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -896,7 +896,7 @@ export const GameState = $root.GameState = (() => {
      * @function encodeDelimited
      * @memberof GameState
      * @static
-     * @param {IGameState} message GameState message or plain object to encode
+     * @param {GameState} message GameState message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1131,7 +1131,7 @@ export const Input = $root.Input = (() => {
      * @function encode
      * @memberof Input
      * @static
-     * @param {IInput} message Input message or plain object to encode
+     * @param {Input} message Input message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1158,7 +1158,7 @@ export const Input = $root.Input = (() => {
      * @function encodeDelimited
      * @memberof Input
      * @static
-     * @param {IInput} message Input message or plain object to encode
+     * @param {Input} message Input message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1366,7 +1366,7 @@ export const UserInputs = $root.UserInputs = (() => {
      * Properties of a UserInputs.
      * @exports IUserInputs
      * @interface IUserInputs
-     * @property {Array.<IInput>|null} [inputs] UserInputs inputs
+     * @property {Array.<Input>|null} [inputs] UserInputs inputs
      */
 
     /**
@@ -1387,7 +1387,7 @@ export const UserInputs = $root.UserInputs = (() => {
 
     /**
      * UserInputs inputs.
-     * @member {Array.<IInput>} inputs
+     * @member {Array.<Input>} inputs
      * @memberof UserInputs
      * @instance
      */
@@ -1410,7 +1410,7 @@ export const UserInputs = $root.UserInputs = (() => {
      * @function encode
      * @memberof UserInputs
      * @static
-     * @param {IUserInputs} message UserInputs message or plain object to encode
+     * @param {UserInputs} message UserInputs message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1428,7 +1428,7 @@ export const UserInputs = $root.UserInputs = (() => {
      * @function encodeDelimited
      * @memberof UserInputs
      * @static
-     * @param {IUserInputs} message UserInputs message or plain object to encode
+     * @param {UserInputs} message UserInputs message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1635,7 +1635,7 @@ export const RunMode = $root.RunMode = (() => {
      * @function encode
      * @memberof RunMode
      * @static
-     * @param {IRunMode} message RunMode message or plain object to encode
+     * @param {RunMode} message RunMode message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1652,7 +1652,7 @@ export const RunMode = $root.RunMode = (() => {
      * @function encodeDelimited
      * @memberof RunMode
      * @static
-     * @param {IRunMode} message RunMode message or plain object to encode
+     * @param {RunMode} message RunMode message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1881,7 +1881,7 @@ export const RuntimeStatus = $root.RuntimeStatus = (() => {
      * @function encode
      * @memberof RuntimeStatus
      * @static
-     * @param {IRuntimeStatus} message RuntimeStatus message or plain object to encode
+     * @param {RuntimeStatus} message RuntimeStatus message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -1906,7 +1906,7 @@ export const RuntimeStatus = $root.RuntimeStatus = (() => {
      * @function encodeDelimited
      * @memberof RuntimeStatus
      * @static
-     * @param {IRuntimeStatus} message RuntimeStatus message or plain object to encode
+     * @param {RuntimeStatus} message RuntimeStatus message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2158,7 +2158,7 @@ export const StartPos = $root.StartPos = (() => {
      * @function encode
      * @memberof StartPos
      * @static
-     * @param {IStartPos} message StartPos message or plain object to encode
+     * @param {StartPos} message StartPos message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2175,7 +2175,7 @@ export const StartPos = $root.StartPos = (() => {
      * @function encodeDelimited
      * @memberof StartPos
      * @static
-     * @param {IStartPos} message StartPos message or plain object to encode
+     * @param {StartPos} message StartPos message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2359,7 +2359,7 @@ export const Text = $root.Text = (() => {
      * @function encode
      * @memberof Text
      * @static
-     * @param {IText} message Text message or plain object to encode
+     * @param {Text} message Text message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2377,7 +2377,7 @@ export const Text = $root.Text = (() => {
      * @function encodeDelimited
      * @memberof Text
      * @static
-     * @param {IText} message Text message or plain object to encode
+     * @param {Text} message Text message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2570,7 +2570,7 @@ export const TimeStamps = $root.TimeStamps = (() => {
      * @function encode
      * @memberof TimeStamps
      * @static
-     * @param {ITimeStamps} message TimeStamps message or plain object to encode
+     * @param {TimeStamps} message TimeStamps message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2589,7 +2589,7 @@ export const TimeStamps = $root.TimeStamps = (() => {
      * @function encodeDelimited
      * @memberof TimeStamps
      * @static
-     * @param {ITimeStamps} message TimeStamps message or plain object to encode
+     * @param {TimeStamps} message TimeStamps message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */


### PR DESCRIPTION
Add `--force-message` for proto autogenerated files so that the type file uses the explicit type instead of the interface type