### PR TITLE
Fix dawn not connecting to Runtime for the first attempt

### DIFF
--- a/main/networking/Runtime.ts
+++ b/main/networking/Runtime.ts
@@ -165,10 +165,11 @@ class RuntimeConnection {
           this.socket.connect(port, ip);
         }
       }
-    }, 1000);
+    }, 3000);
 
     this.socket.on('connect', () => {
       this.logger.log('Runtime connected');
+      
       this.socket.write(new Uint8Array([1])); // Runtime needs first byte to be 1 to recognize client as Dawn (instead of Shepherd)
     });
 


### PR DESCRIPTION
This happens due to race condition when it periodically tries to connect to Runtime. I fixed it by increasing the delay time for the timer. 